### PR TITLE
Size adjustments to ensure tile flips maintain same tile size

### DIFF
--- a/src/components/tileView/tileGrid.jsx
+++ b/src/components/tileView/tileGrid.jsx
@@ -146,7 +146,7 @@ export const TileGrid = () => {
       {/* Force tailwind to recognize these classes for tree shaking */}
       {/*<div className="hidden grid-cols-6 grid-cols-8"></div>*/}
       {/*<div className={`grid gap-2 grid-cols-${tilesPerRow}`}>*/}
-      <div className="main_container relative mx-5 mb-20 mt-20 grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="main_container relative mx-5 mb-20 mt-20 grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {filteredElements &&
           filteredElements.map((tile, index) => (
             <div

--- a/src/components/tileView/tileTypes/bountyDetailTile.jsx
+++ b/src/components/tileView/tileTypes/bountyDetailTile.jsx
@@ -25,7 +25,7 @@ export const BountyDetailTile = (props) => {
 
   return (
     <div
-      className="mx-auto grid w-full flex-1 grid-cols-1 content-between rounded-lg bg-[#FBF8EC]"
+      className="mx-auto grid h-full w-full flex-1 grid-cols-1 content-between rounded-lg bg-[#FBF8EC]"
       onClick={handleClick}
     >
       <div className="img_container relative">

--- a/src/components/tileView/tileTypes/bountyTile.jsx
+++ b/src/components/tileView/tileTypes/bountyTile.jsx
@@ -11,7 +11,7 @@ export const BountyTile = (props) => {
     <div className="mx-auto grid w-full flex-1 grid-cols-1 content-between">
       <div className="img_container relative">
         <div
-          className="bounty_img relative inline-block h-96 w-full rounded-lg bg-cover bg-center bg-no-repeat"
+          className="bounty_img relative inline-block h-96 max-h-[300px] w-full rounded-lg bg-cover bg-center bg-no-repeat"
           style={{ backgroundImage: `url(${Helpers.getTileImage(tile)})` }}
         />
         <div

--- a/src/components/tileView/tileTypes/fundraiserDetailTile.jsx
+++ b/src/components/tileView/tileTypes/fundraiserDetailTile.jsx
@@ -30,7 +30,7 @@ export const FundraiserDetailTile = (props) => {
 
   return (
     <div
-      className="fundraiser_card relative mx-auto flex w-full rounded-lg bg-[#FBF8EC] px-4 pb-6 pt-4 shadow-xl ring-1 ring-gray-900/5 hover:bg-gray-100"
+      className="fundraiser_card relative mx-auto flex h-full w-full rounded-lg bg-[#FBF8EC] px-4 pb-6 pt-4 shadow-xl ring-1 ring-gray-900/5 hover:bg-gray-100"
       onClick={handleClick}
     >
       <div className="mx-auto grid w-full flex-1 grid-cols-1 content-between">

--- a/src/components/tileView/tileTypes/fundraiserTile.jsx
+++ b/src/components/tileView/tileTypes/fundraiserTile.jsx
@@ -16,7 +16,7 @@ export const FundraiserTile = (props) => {
     <div className="mx-auto grid w-full flex-1 grid-cols-1 content-between">
       <div className="img_container relative">
         <img
-          className="fundraiser_img relative inline-block h-96 w-full rounded-lg bg-cover bg-center bg-no-repeat"
+          className="fundraiser_img relative inline-block h-96 max-h-[300px] w-full rounded-lg bg-cover bg-center bg-no-repeat"
           src={Helpers.getTileImage(tile)}
         />
         <div

--- a/src/components/tileView/tileTypes/islandDetailTile.jsx
+++ b/src/components/tileView/tileTypes/islandDetailTile.jsx
@@ -56,7 +56,7 @@ export const IslandDetailTile = (props) => {
   };
 
   return (
-    <div className="main_card relative mx-auto flex w-full cursor-default rounded-lg bg-[#FBF8EC] px-4 pb-6 pt-4 shadow-xl ring-1 ring-gray-900/5 hover:bg-gray-100">
+    <div className="main_card relative mx-auto flex h-full w-full cursor-default rounded-lg bg-[#FBF8EC] px-4 pb-6 pt-4 shadow-xl ring-1 ring-gray-900/5 hover:bg-gray-100">
       <div className="mx-auto grid w-full flex-1 grid-cols-1 content-between">
         <div className="img_container relative w-full justify-center pt-[140px]">
           <div

--- a/src/components/tileView/tileTypes/subscriptionDetailTile.jsx
+++ b/src/components/tileView/tileTypes/subscriptionDetailTile.jsx
@@ -26,7 +26,7 @@ export const SubscriptionDetailTile = (props) => {
 
   return (
     <div
-      className="mx-auto grid w-full flex-1 grid-cols-1 content-between rounded-lg bg-[#FBF8EC]"
+      className="mx-auto grid h-full w-full flex-1 grid-cols-1 content-between rounded-lg bg-[#FBF8EC]"
       onClick={handleClick}
     >
       <div className="img_container relative">

--- a/src/components/tileView/tileTypes/subscriptionTile.jsx
+++ b/src/components/tileView/tileTypes/subscriptionTile.jsx
@@ -10,7 +10,7 @@ export const SubscriptionTile = (props) => {
     <div className="mx-auto grid w-full flex-1 grid-cols-1 content-between">
       <div className="img_container relative">
         <div
-          className="subscription_img relative inline-block h-96 w-full rounded-lg bg-cover bg-center bg-no-repeat"
+          className="subscription_img relative inline-block h-96 max-h-[300px] w-full rounded-lg bg-cover bg-center bg-no-repeat"
           style={{ backgroundImage: `url(${Helpers.getTileImage(tile)})` }}
         />
         <div

--- a/src/index.css
+++ b/src/index.css
@@ -151,8 +151,6 @@ input, textarea {
   cursor: pointer;
   border-radius: 0.375rem; /* Tailwind's 'rounded-md' */
   transition: all 0.3s ease;
-  min-width: 350px;
-  min-height: 600px;
 }
 
 .tile {


### PR DESCRIPTION
- [x] Update index.css to remove max w & h values
- [x] Update each tile & DetailTile to update max image height and h-full respectively

This will keep the tiles the same size on hover, i.e. when they 'flip'